### PR TITLE
Fix, dont delete a Qt object when ownership is set.

### DIFF
--- a/core/backends/lan/lanlinkprovider.cpp
+++ b/core/backends/lan/lanlinkprovider.cpp
@@ -146,7 +146,7 @@ void LanLinkProvider::connectError()
     //to create a LanDeviceLink from it, deleting everything.
     delete receivedIdentityPackages[socket].np;
     receivedIdentityPackages.remove(socket);
-    delete socket;
+    socket->deleteLater();
 }
 
 void LanLinkProvider::connected()


### PR DESCRIPTION
And dont delete the Qt object signal in a slot.