### PR TITLE
Add configuration UI to the telephony plugin

### DIFF
--- a/daemon/kdeconnectd.desktop.cmake
+++ b/daemon/kdeconnectd.desktop.cmake
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Exec=${LIBEXEC_INSTALL_DIR}/kdeconnectd
+Exec=@KDE_INSTALL_FULL_LIBEXECDIR@/kdeconnectd
 X-KDE-StartupNotify=false
 X-KDE-autostart-phase=0
 X-GNOME-Autostart-enabled=true

--- a/plugins/telephony/CMakeLists.txt
+++ b/plugins/telephony/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(KF5 REQUIRED COMPONENTS Notifications)
+find_package(KF5 REQUIRED COMPONENTS Notifications KCMUtils)
 
 set(kdeconnect_telephony_SRCS
     telephonyplugin.cpp
@@ -18,3 +18,20 @@ target_link_libraries(kdeconnect_telephony
     connectcm
 )
 endif()
+
+#######################################
+# Config
+
+set( kdeconnect_telephony_config_SRCS telephony_config.cpp )
+ki18n_wrap_ui( kdeconnect_telephony_config_SRCS telephony_config.ui )
+
+add_library(kdeconnect_telephony_config MODULE ${kdeconnect_telephony_config_SRCS} )
+target_link_libraries( kdeconnect_telephony_config
+    kdeconnectcore
+    kdeconnectpluginkcm
+    KF5::I18n
+    KF5::KCMUtils
+)
+
+install( TARGETS kdeconnect_telephony_config DESTINATION ${PLUGIN_INSTALL_DIR} )
+install( FILES kdeconnect_telephony_config.desktop DESTINATION ${SERVICES_INSTALL_DIR} )

--- a/plugins/telephony/kdeconnect_telephony_config.desktop
+++ b/plugins/telephony/kdeconnect_telephony_config.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Type=Service
+X-KDE-ServiceTypes=KCModule
+
+X-KDE-Library=kdeconnect_telephony_config
+X-KDE-ParentComponents=kdeconnect_telephony
+
+Name=Telephony plugin settings
+Name[en_GB]=Telephony plugin settings
+Name[pt]=Configuração do 'plugin' de chamadas/sms
+Name[pt_BR]=Configuração do 'plugin' de chamadas/sms
+
+Categories=Qt;KDE;X-KDE-settings-kdeconnect;

--- a/plugins/telephony/telephony_config.cpp
+++ b/plugins/telephony/telephony_config.cpp
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2013 Albert Vaca <albertvaka@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License or (at your option) version 3 or any later version
+ * accepted by the membership of KDE e.V. (or its successor approved
+ * by the membership of KDE e.V.), which shall act as a proxy
+ * defined in Section 14 of version 3 of the license.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "telephony_config.h"
+#include "ui_telephony_config.h"
+
+#include <KPluginFactory>
+
+K_PLUGIN_FACTORY(TelephonyConfigFactory, registerPlugin<TelephonyConfig>();)
+
+TelephonyConfig::TelephonyConfig(QWidget *parent, const QVariantList& args)
+    : KdeConnectPluginKcm(parent, args, "kdeconnect_telephony_config")
+    , m_ui(new Ui::TelephonyConfigUi())
+{
+    m_ui->setupUi(this);
+
+    connect(m_ui->show_name, SIGNAL(toggled(bool)), this, SLOT(changed()));
+    connect(m_ui->show_number, SIGNAL(toggled(bool)), this, SLOT(changed()));
+}
+
+TelephonyConfig::~TelephonyConfig()
+{
+    delete m_ui;
+}
+
+void TelephonyConfig::defaults()
+{
+    KCModule::defaults();
+    m_ui->show_name->setChecked(true);
+    m_ui->show_number->setChecked(true);
+    Q_EMIT changed(true);
+}
+
+void TelephonyConfig::load()
+{
+    KCModule::load();
+    bool name = config()->get("showName", true);
+    bool number = config()->get("showNumber", false);
+    m_ui->show_name->setChecked(name);
+    m_ui->show_number->setChecked(number);
+    Q_EMIT changed(false);
+}
+
+void TelephonyConfig::save()
+{
+    config()->set("showName", m_ui->show_name->isChecked());
+    config()->set("showNumber", m_ui->show_number->isChecked());
+    KCModule::save();
+    Q_EMIT changed(false);
+}
+
+#include "telephony_config.moc"

--- a/plugins/telephony/telephony_config.h
+++ b/plugins/telephony/telephony_config.h
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2013 Albert Vaca <albertvaka@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License or (at your option) version 3 or any later version
+ * accepted by the membership of KDE e.V. (or its successor approved
+ * by the membership of KDE e.V.), which shall act as a proxy
+ * defined in Section 14 of version 3 of the license.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TELEPHONY_CONFIG_H
+#define TELEPHONY_CONFIG_H
+
+#include "kcmplugin/kdeconnectpluginkcm.h"
+
+namespace Ui {
+    class TelephonyConfigUi;
+}
+
+class TelephonyConfig
+    : public KdeConnectPluginKcm
+{
+    Q_OBJECT
+public:
+    TelephonyConfig(QWidget *parent, const QVariantList&);
+    virtual ~TelephonyConfig();
+
+public Q_SLOTS:
+    virtual void save() override;
+    virtual void load() override;
+    virtual void defaults() override;
+
+private:
+    Ui::TelephonyConfigUi* m_ui;
+
+};
+
+#endif

--- a/plugins/telephony/telephony_config.ui
+++ b/plugins/telephony/telephony_config.ui
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>TelephonyConfigUi</class>
+ <widget class="QWidget" name="TelephonyConfigUi">
+  <property name="windowModality">
+   <enum>Qt::WindowModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>359</width>
+    <height>129</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Telephony plugin</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_3">
+   <property name="spacing">
+    <number>20</number>
+   </property>
+   <item>
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="title">
+      <string>Contact information</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QCheckBox" name="show_name">
+        <property name="text">
+         <string>Display contact name</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="show_number">
+        <property name="text">
+         <string>Display contact number</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/plugins/telephony/telephonyplugin.cpp
+++ b/plugins/telephony/telephonyplugin.cpp
@@ -46,7 +46,27 @@ KNotification* TelephonyPlugin::createNotification(const NetworkPackage& np)
 {
     const QString event = np.get<QString>("event");
     const QString phoneNumber = np.get<QString>("phoneNumber", i18n("unknown number"));
-    const QString contactName = np.get<QString>("contactName", phoneNumber);
+    const QString contactName = np.get<QString>("contactName", i18n("unknown"));
+    bool show_name = config()->get("showName", true);
+    bool show_number = config()->get("showNumber", true);
+    QString contactInformation;
+
+    if (!show_name && !show_number)
+    {
+        show_name = show_number = true;
+    }
+    if (show_name)
+    {
+        contactInformation = contactName;
+        if ( show_number)
+        {
+            contactInformation += " (" + phoneNumber + ")";
+        }
+    }
+    else
+    {
+        contactInformation = phoneNumber;
+    }
 
     QString content, type, icon;
     KNotification::NotificationFlags flags = KNotification::CloseOnTimeout | KNotification::CloseWhenWidgetActivated;
@@ -66,7 +86,7 @@ KNotification* TelephonyPlugin::createNotification(const NetworkPackage& np)
         type = QStringLiteral("smsReceived");
         icon = QStringLiteral("mail-receive");
         QString messageBody = np.get<QString>("messageBody","");
-        content = i18n("SMS from %1<br>%2", contactName, messageBody);
+        content = i18n("SMS from %1<br>%2", contactInformation, messageBody);
         flags |= KNotification::Persistent;
     } else if (event == "talking") {
         return nullptr;


### PR DESCRIPTION
Add configuration UI to the telephony plugin in order to select the contact information to display in the notification. This changes enables the user to select if the notification should display the number or only the contact name if available. Since the notification size is limited, the information to display should be reduced, and contact name and number seem a bit redundant.