### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+This information is provided for Github users who may wonder why issues are disabled.
+
+To file bugs, use the [kde bugtracker](https://bugs.kde.org/describecomponents.cgi?product=kdeconnect).
+
+To request features, join the discussion on the [mailing list](https://mail.kde.org/mailman/listinfo/kdeconnect).


### PR DESCRIPTION
Since the links to the bugtracker and mailinglist are not trivial to
find, they are included in the CONTRIBUTING.md file, which is github's
convention for informing users.